### PR TITLE
Fix #14 with file paths on windows

### DIFF
--- a/cme/protocols/ldap.py
+++ b/cme/protocols/ldap.py
@@ -292,8 +292,7 @@ class ldap(connection):
 
             # Re-connect since we logged off
             self.create_conn_obj()
-        self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}")
-        self.output_filename = self.output_filename.replace(":", "-")
+        self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
 
     def print_host_info(self):
         self.logger.debug("Printing host info for LDAP")

--- a/cme/protocols/rdp.py
+++ b/cme/protocols/rdp.py
@@ -133,8 +133,7 @@ class rdp(connection):
                     self.server_os = info_domain["os_guess"] + " Build " + str(info_domain["os_build"])
                     self.logger.extra["hostname"] = self.hostname
 
-                    self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}")
-                    self.output_filename = self.output_filename.replace(":", "-")
+                    self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
                     break
 
         if self.args.domain:

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -234,8 +234,7 @@ class smb(connection):
             pass
 
         self.os_arch = self.get_os_arch()
-        self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}")
-        self.output_filename = self.output_filename.replace(":", "-")
+        self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
 
         if not self.domain:
             self.domain = self.hostname

--- a/cme/protocols/winrm.py
+++ b/cme/protocols/winrm.py
@@ -91,8 +91,7 @@ class winrm(connection):
 
             self.db.add_host(self.host, self.port, self.hostname, self.domain, self.server_os)
 
-        self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}")
-        self.output_filename = self.output_filename.replace(":", "-")
+        self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
 
     def laps_search(self, username, password, ntlm_hash, domain):
         ldapco = LDAPConnect(self.domain, "389", self.domain)


### PR DESCRIPTION
This fixes #14 by removing ":" on the file name before expanding the path, so "C:/" won't be replaced by "C-/" as described in the issue