### PR TITLE
Fixes and Improvements

### DIFF
--- a/cme/cli.py
+++ b/cme/cli.py
@@ -144,6 +144,8 @@ def gen_cli_args():
     std_parser.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication")
     std_parser.add_argument("--no-bruteforce", action="store_true", help="No spray when using file for username and password (user1 => password1, user2 => password2")
     std_parser.add_argument("--continue-on-success", action="store_true", help="continues authentication attempts even after successes")
+    std_parser.add_argument("--continue-until-admin", action='store_true', help="continues authentication attempts until success admin authentication")
+    
     std_parser.add_argument(
         "--use-kcache",
         action="store_true",

--- a/cme/connection.py
+++ b/cme/connection.py
@@ -388,16 +388,21 @@ class connection(object):
                 for user_index, user in enumerate(username):
                     if self.try_credentials(domain[user_index], user, owned[user_index], secr, cred_type[secr_index], data[secr_index]):
                         owned[user_index] = True
-                        if not self.args.continue_on_success:
+                        if self.args.continue_until_admin and self.admin_privs:
+                            return True
+                        if not (self.args.continue_on_success or self.args.continue_until_admin):
                             return True
         else:
+
             if len(username) != len(secret):
                 self.logger.error("Number provided of usernames and passwords/hashes do not match!")
                 return False
             for user_index, user in enumerate(username):
                 if self.try_credentials(domain[user_index], user, owned[user_index], secret[user_index], cred_type[user_index], data[user_index]) and not self.args.continue_on_success:
                     owned[user_index] = True
-                    if not self.args.continue_on_success:
+                    if self.args.continue_until_admin and self.admin_privs:
+                        return True
+                    if not (self.args.continue_on_success or self.args.continue_until_admin):
                         return True
 
     def mark_pwned(self):

--- a/cme/helpers/bloodhound.py
+++ b/cme/helpers/bloodhound.py
@@ -36,11 +36,11 @@ def add_user_bh(user, domain, logger, config):
                             user_owned = info["username"] + "@" + info["domain"]
                             account_type = "User"
 
-                        result = tx.run(f'MATCH (c:{account_type} {{name:"{user_owned}"}}) RETURN c')
+                        result = tx.run(f'MATCH (c:{account_type}) where c.name =~\"{user_owned}.*\" RETURN c')
 
                         if result.data()[0]["c"].get("owned") in (False, None):
-                            logger.debug(f'MATCH (c:{account_type} {{name:"{user_owned}"}}) SET c.owned=True RETURN c.name AS name')
-                            result = tx.run(f'MATCH (c:{account_type} {{name:"{user_owned}"}}) SET c.owned=True RETURN c.name AS name')
+                            logger.debug(f'MATCH (c:{account_type}) where c.name =~\"{user_owned}.*\" SET c.owned=True RETURN c.name AS name')
+                            result = tx.run(f'MATCH (c:{account_type}) where c.name =~\"{user_owned}.*\" SET c.owned=True RETURN c.name AS name')
                             logger.highlight(f"Node {user_owned} successfully set as owned in BloodHound")
         except AuthError as e:
             logger.fail(f"Provided Neo4J credentials ({config.get('BloodHound', 'bh_user')}:{config.get('BloodHound', 'bh_pass')}) are not valid.")

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -607,8 +607,7 @@ class smb(connection):
             self.smbv1 = False
         except socket.error as e:
             if str(e).find("Too many open files") != -1:
-                if not logger is None:
-                    self.logger.fail(f"SMBv3 connection error on {self.host if not kdc else kdc}: {e}")
+                self.logger.fail(f"SMBv3 connection error on {self.host if not kdc else kdc}: {e}")
             return False
         except (Exception, NetBIOSTimeout) as e:
             self.logger.info(f"Error creating SMBv3 connection to {self.host if not kdc else kdc}: {e}")
@@ -630,10 +629,7 @@ class smb(connection):
         except:
             pass
         else:
-            try:
-                dce.bind(scmr.MSRPC_UUID_SCMR)
-            except:
-                pass
+            dce.bind(scmr.MSRPC_UUID_SCMR)
             try:
                 # 0xF003F - SC_MANAGER_ALL_ACCESS
                 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -629,7 +629,10 @@ class smb(connection):
         except:
             pass
         else:
-            dce.bind(scmr.MSRPC_UUID_SCMR)
+            try:
+                dce.bind(scmr.MSRPC_UUID_SCMR)
+            except:
+                pass
             try:
                 # 0xF003F - SC_MANAGER_ALL_ACCESS
                 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -607,7 +607,8 @@ class smb(connection):
             self.smbv1 = False
         except socket.error as e:
             if str(e).find("Too many open files") != -1:
-                self.logger.fail(f"SMBv3 connection error on {self.host if not kdc else kdc}: {e}")
+                if not logger is None:
+                    self.logger.fail(f"SMBv3 connection error on {self.host if not kdc else kdc}: {e}")
             return False
         except (Exception, NetBIOSTimeout) as e:
             self.logger.info(f"Error creating SMBv3 connection to {self.host if not kdc else kdc}: {e}")


### PR DESCRIPTION
- 2448451cb66357fafb55698408c99e066ba48761: Fixing a major flaw in the hash_spider module where it was not saving hashes to cmedb. I have implemented the structure from the lsassy module to resolve this issue.

- c3c1d3071276448d8c9cc02fffacf37266aa4a61 #252: I also encountered the same problem mentioned in issue . It seems that we encounter this error on unsupported SMB versions (likely non-Windows devices such as NAS). This error was causing the program to exit completely when running cme with a list. Therefore, I thought it would be a good idea to add a try-catch block to handle this scenario.

- 62f6cfd3eaf115013cee7a28180e234209ae3447 increasing ulimit -n and ulimit -u, along with this fix, prevented me from encountering the mentioned error.

- 504193727a846458269e6b1f5d2f23c9975c58c8: Lastly, when performing a login without providing the full FQDN (e.g., DOMAIN/USER. not DOMAIN.LOCAL/USER), Therefore, I found it appropriate to add a regex match in the query for Neo4j to ensure compatibility. Of course, the full FQDN can still be used in query, but I'm not certain if BloodHound always adds it to Neo4j.
