### PR TITLE
Fix AES authentication for SMB

### DIFF
--- a/cme/connection.py
+++ b/cme/connection.py
@@ -51,8 +51,8 @@ class connection(object):
         self.admin_privs = False
         self.password = ""
         self.username = ""
-        self.kerberos = True if self.args.kerberos or self.args.use_kcache else False
-        self.aesKey = None if not self.args.aesKey else self.args.aesKey
+        self.kerberos = True if self.args.kerberos or self.args.use_kcache or self.args.aesKey else False
+        self.aesKey = None if not self.args.aesKey else self.args.aesKey[0]
         self.kdcHost = None if not self.args.kdcHost else self.args.kdcHost
         self.use_kcache = None if not self.args.use_kcache else self.args.use_kcache
         self.failed_logins = 0

--- a/cme/modules/dfscoerce.py
+++ b/cme/modules/dfscoerce.py
@@ -41,6 +41,7 @@ class CMEModule:
             target=connection.host if not connection.kerberos else connection.hostname + "." + connection.domain,
             doKerberos=connection.kerberos,
             dcHost=connection.kdcHost,
+            aesKey=connection.aesKey,
         )
 
         if dce is not None:
@@ -103,7 +104,7 @@ class NetrDfsAddRootResponse(NDRCALL):
 
 
 class TriggerAuth:
-    def connect(self, username, password, domain, lmhash, nthash, target, doKerberos, dcHost):
+    def connect(self, username, password, domain, lmhash, nthash, aesKey, target, doKerberos, dcHost):
         rpctransport = transport.DCERPCTransportFactory(r"ncacn_np:%s[\PIPE\netdfs]" % target)
         if hasattr(rpctransport, "set_credentials"):
             rpctransport.set_credentials(
@@ -112,6 +113,7 @@ class TriggerAuth:
                 domain=domain,
                 lmhash=lmhash,
                 nthash=nthash,
+                aesKey=aesKey,
             )
 
         if doKerberos:

--- a/cme/modules/enum_av.py
+++ b/cme/modules/enum_av.py
@@ -55,7 +55,7 @@ class CMEModule:
                 for service in product["services"]:
                     try:
                         lsa.LsarLookupNames(dce, policyHandle, service["name"])
-                        context.log.display(f"Detected installed service on {connection.host}: {product['name']} {service['description']}")
+                        context.log.info(f"Detected installed service on {connection.host}: {product['name']} {service['description']}")
                         if product["name"] not in results:
                             results[product["name"]] = {"services": []}
                         results[product["name"]]["services"].append(service)
@@ -65,7 +65,7 @@ class CMEModule:
         except Exception as e:
             context.log.fail(str(e))
 
-        context.log.display(f"Detecting running processes on {connection.host} by enumerating pipes...")
+        context.log.info(f"Detecting running processes on {connection.host} by enumerating pipes...")
         try:
             for f in connection.conn.listPath("IPC$", "\\*"):
                 fl = f.get_longname()

--- a/cme/modules/enum_av.py
+++ b/cme/modules/enum_av.py
@@ -46,6 +46,7 @@ class CMEModule:
                 connection.domain,
                 connection.lmhash,
                 connection.nthash,
+                connection.aesKey,
             )
             dce, rpctransport = lsa.connect()
             policyHandle = lsa.open_policy(dce)
@@ -124,6 +125,7 @@ class LsaLookupNames:
         kdcHost="",
         lmhash="",
         nthash="",
+        aesKey="",
     ):
         self.domain = domain
         self.username = username
@@ -133,6 +135,7 @@ class LsaLookupNames:
         self.doKerberos = k
         self.lmhash = lmhash
         self.nthash = nthash
+        self.aesKey = aesKey
         self.dcHost = kdcHost
 
     def connect(self, string_binding=None, iface_uuid=None):
@@ -154,7 +157,7 @@ class LsaLookupNames:
         # Authenticate if specified
         if self.authn and hasattr(rpc_transport, "set_credentials"):
             # This method exists only for selected protocol sequences.
-            rpc_transport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
+            rpc_transport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash, self.aesKey)
 
         if self.doKerberos:
             rpc_transport.set_kerberos(self.doKerberos, kdcHost=self.dcHost)

--- a/cme/modules/petitpotam.py
+++ b/cme/modules/petitpotam.py
@@ -45,6 +45,7 @@ class CMEModule:
             domain=connection.domain,
             lmhash=connection.lmhash,
             nthash=connection.nthash,
+            aesKey=connection.aesKey,
             target=connection.host if not connection.kerberos else connection.hostname + "." + connection.domain,
             pipe=self.pipe,
             do_kerberos=connection.kerberos,
@@ -195,6 +196,7 @@ def coerce(
     domain,
     lmhash,
     nthash,
+    aesKey,
     target,
     pipe,
     do_kerberos,
@@ -232,6 +234,7 @@ def coerce(
             domain=domain,
             lmhash=lmhash,
             nthash=nthash,
+            aesKey=aesKey,
         )
 
     if target_ip:

--- a/cme/modules/printnightmare.py
+++ b/cme/modules/printnightmare.py
@@ -56,6 +56,7 @@ class CMEModule:
             connection.domain,
             connection.lmhash,
             connection.nthash,
+            connection.aesKey,
         )
 
         rpctransport.set_kerberos(connection.kerberos, kdcHost=connection.kdcHost)

--- a/cme/modules/shadowcoerce.py
+++ b/cme/modules/shadowcoerce.py
@@ -45,6 +45,7 @@ class CMEModule:
             domain=connection.domain,
             lmhash=connection.lmhash,
             nthash=connection.nthash,
+            aesKey=connection.aesKey,
             target=connection.host if not connection.kerberos else connection.hostname + "." + connection.domain,
             pipe="FssagentRpc",
             doKerberos=connection.kerberos,
@@ -62,6 +63,7 @@ class CMEModule:
                 domain=connection.domain,
                 lmhash=connection.lmhash,
                 nthash=connection.nthash,
+                aesKey=connection.aesKey,
                 target=connection.host if not connection.kerberos else connection.hostname + "." + connection.domain,
                 pipe="FssagentRpc",
             )
@@ -194,6 +196,7 @@ class CoerceAuth:
         domain,
         lmhash,
         nthash,
+        aesKey,
         target,
         pipe,
         doKerberos,
@@ -215,6 +218,7 @@ class CoerceAuth:
                 domain=domain,
                 lmhash=lmhash,
                 nthash=nthash,
+                aesKey=aesKey,
             )
 
         dce.set_credentials(*rpctransport.get_credentials())

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -1004,7 +1004,7 @@ class smb(connection):
                 groups = SamrFunc(self).get_local_groups()
                 if groups:
                     self.logger.success("Enumerated local groups")
-                    self.logger.display(f"Local groups: {groups}")
+                    self.logger.debug(f"Local groups: {groups}")
 
                 for group_name, group_rid in groups.items():
                     self.logger.highlight(f"rid => {group_rid} => {group_name}")

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -1277,7 +1277,7 @@ class smb(connection):
 
             if hasattr(rpc_transport, "set_credentials"):
                 # This method exists only for selected protocol sequences.
-                rpc_transport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
+                rpc_transport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash, self.aesKey)
 
             if self.kerberos:
                 rpc_transport.set_kerberos(self.kerberos, self.kdcHost)

--- a/cme/protocols/smb/passpol.py
+++ b/cme/protocols/smb/passpol.py
@@ -80,7 +80,7 @@ class PassPolDump:
         self.hash = connection.hash
         self.lmhash = ""
         self.nthash = ""
-        self.aesKey = None
+        self.aesKey = connection.aesKey
         self.doKerberos = connection.kerberos
         self.protocols = PassPolDump.KNOWN_PROTOCOLS.keys()
         self.pass_pol = {}

--- a/cme/protocols/smb/samrfunc.py
+++ b/cme/protocols/smb/samrfunc.py
@@ -25,7 +25,7 @@ class SamrFunc:
         self.hash = connection.hash
         self.lmhash = ""
         self.nthash = ""
-        self.aesKey = (None,)
+        self.aesKey = connection.aesKey
         self.doKerberos = connection.kerberos
 
         if self.hash is not None:
@@ -40,16 +40,20 @@ class SamrFunc:
         self.samr_query = SAMRQuery(
             username=self.username,
             password=self.password,
+            domain=self.domain,
             remote_name=self.addr,
             remote_host=self.addr,
             kerberos=self.doKerberos,
+            aesKey=self.aesKey,
         )
         self.lsa_query = LSAQuery(
             username=self.username,
             password=self.password,
+            domain=self.domain,
             remote_name=self.addr,
             remote_host=self.addr,
             kerberos=self.doKerberos,
+            aesKey=self.aesKey,
             logger=self.logger
         )
 
@@ -107,13 +111,14 @@ class SAMRQuery:
         remote_name="",
         remote_host="",
         kerberos=None,
+        aesKey="",
     ):
         self.__username = username
         self.__password = password
         self.__domain = domain
         self.__lmhash = ""
         self.__nthash = ""
-        self.__aesKey = None
+        self.__aesKey = aesKey
         self.__port = port
         self.__remote_name = remote_name
         self.__remote_host = remote_host
@@ -207,6 +212,7 @@ class LSAQuery:
         port=445,
         remote_name="",
         remote_host="",
+        aesKey="",
         kerberos=None,
         logger=None
     ):
@@ -215,7 +221,7 @@ class LSAQuery:
         self.__domain = domain
         self.__lmhash = ""
         self.__nthash = ""
-        self.__aesKey = None
+        self.__aesKey = aesKey
         self.__port = port
         self.__remote_name = remote_name
         self.__remote_host = remote_host

--- a/cme/protocols/smb/samruser.py
+++ b/cme/protocols/smb/samruser.py
@@ -24,7 +24,7 @@ class UserSamrDump:
         self.hash = connection.hash
         self.lmhash = ""
         self.nthash = ""
-        self.aesKey = None
+        self.aesKey = connection.aesKey
         self.doKerberos = connection.kerberos
         self.protocols = UserSamrDump.KNOWN_PROTOCOLS.keys()
         self.users = []


### PR DESCRIPTION
Hello, 

While testing the authentication using the AES key, I've noticed some errors while using SMB modules or functions `--pass-pol`, `--users`, `--local-groups`, `-M petitpotam`, `-M dfscoerce`, `-M shadowcoerce`, `-M enum_av`, `-M printnightmare`. 
I made these changes, and the fixes are working for me. Attached are the outputs before and after the fixes.

[before.txt](https://github.com/mpgn/CrackMapExec/files/11939854/before.txt)
[after.txt](https://github.com/mpgn/CrackMapExec/files/11939851/after.txt)

Please let me know if the fixes work for you as well. 

Thanks!