### PR TITLE
Add continue-until-admin argument

### DIFF
--- a/cme/cli.py
+++ b/cme/cli.py
@@ -144,6 +144,8 @@ def gen_cli_args():
     std_parser.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication")
     std_parser.add_argument("--no-bruteforce", action="store_true", help="No spray when using file for username and password (user1 => password1, user2 => password2")
     std_parser.add_argument("--continue-on-success", action="store_true", help="continues authentication attempts even after successes")
+    std_parser.add_argument("--continue-until-admin", action='store_true', help="continues authentication attempts until success admin authentication")
+    
     std_parser.add_argument(
         "--use-kcache",
         action="store_true",

--- a/cme/connection.py
+++ b/cme/connection.py
@@ -388,16 +388,21 @@ class connection(object):
                 for user_index, user in enumerate(username):
                     if self.try_credentials(domain[user_index], user, owned[user_index], secr, cred_type[secr_index], data[secr_index]):
                         owned[user_index] = True
-                        if not self.args.continue_on_success:
+                        if self.args.continue_until_admin and self.admin_privs:
+                            return True
+                        if not (self.args.continue_on_success or self.args.continue_until_admin):
                             return True
         else:
+
             if len(username) != len(secret):
                 self.logger.error("Number provided of usernames and passwords/hashes do not match!")
                 return False
             for user_index, user in enumerate(username):
                 if self.try_credentials(domain[user_index], user, owned[user_index], secret[user_index], cred_type[user_index], data[user_index]) and not self.args.continue_on_success:
                     owned[user_index] = True
-                    if not self.args.continue_on_success:
+                    if self.args.continue_until_admin and self.admin_privs:
+                        return True
+                    if not (self.args.continue_on_success or self.args.continue_until_admin):
                         return True
 
     def mark_pwned(self):


### PR DESCRIPTION
If user is successful, it continues to attempt session logins until it finds an admin account.

The comparison is shown below.
![Screenshot](https://i.ibb.co/pyQ0ntj/Screenshot-2023-07-03-at-21-41-23.png)

