### PR TITLE
hash_spider module saving hashes to cmedb.

### DIFF
--- a/cme/modules/hash_spider.py
+++ b/cme/modules/hash_spider.py
@@ -147,7 +147,15 @@ class CMEModule:
         self.reset = None
         self.reset_dumped = None
         self.method = None
-
+    @staticmethod
+    def save_credentials(context, connection, domain, username, password, lmhash, nthash):
+        host_id = context.db.get_computers(connection.host)[0][0]
+        if password is not None:
+            credential_type = 'plaintext'
+        else:
+            credential_type = 'hash'
+            password = ':'.join(h for h in [lmhash, nthash] if h is not None)
+        context.db.add_credential(credential_type, domain, username, password, pillaged_from=host_id)
     def options(self, context, module_options):
         """
         METHOD              Method to use to dump lsass.exe with lsassy
@@ -222,6 +230,7 @@ class CMEModule:
                     ]
                 )
                 credentials_output.append(cred)
+                self.save_credentials(context, connection, cred["domain"], cred["username"], cred["password"], cred["lmhash"], cred["nthash"])
         global credentials_data
         credentials_data = credentials_output
 


### PR DESCRIPTION
- 3fd728499d2a7178610626e335cf79ecb6b24c94 : Fixing a major flaw in the hash_spider module where it was not saving hashes to cmedb. I have implemented the structure from the lsassy module to resolve this issue.