### PR TITLE
"Too many open files" errors cause some targets

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -607,7 +607,8 @@ class smb(connection):
             self.smbv1 = False
         except socket.error as e:
             if str(e).find("Too many open files") != -1:
-                self.logger.fail(f"SMBv3 connection error on {self.host if not kdc else kdc}: {e}")
+                if not logger is None:
+                    self.logger.fail(f"SMBv3 connection error on {self.host if not kdc else kdc}: {e}")
             return False
         except (Exception, NetBIOSTimeout) as e:
             self.logger.info(f"Error creating SMBv3 connection to {self.host if not kdc else kdc}: {e}")


### PR DESCRIPTION
- 5936936406ebf10516f2d0e95a6a72a740cfa91a : #489 increasing ulimit -n and ulimit -u, along with this fix, prevented me from encountering the mentioned error.