### PR TITLE
add a regex match in the query for Neo4j

### DIFF
--- a/cme/helpers/bloodhound.py
+++ b/cme/helpers/bloodhound.py
@@ -36,11 +36,11 @@ def add_user_bh(user, domain, logger, config):
                             user_owned = info["username"] + "@" + info["domain"]
                             account_type = "User"
 
-                        result = tx.run(f'MATCH (c:{account_type} {{name:"{user_owned}"}}) RETURN c')
+                        result = tx.run(f'MATCH (c:{account_type}) where c.name =~\"{user_owned}.*\" RETURN c')
 
                         if result.data()[0]["c"].get("owned") in (False, None):
-                            logger.debug(f'MATCH (c:{account_type} {{name:"{user_owned}"}}) SET c.owned=True RETURN c.name AS name')
-                            result = tx.run(f'MATCH (c:{account_type} {{name:"{user_owned}"}}) SET c.owned=True RETURN c.name AS name')
+                            logger.debug(f'MATCH (c:{account_type}) where c.name =~\"{user_owned}.*\" SET c.owned=True RETURN c.name AS name')
+                            result = tx.run(f'MATCH (c:{account_type}) where c.name =~\"{user_owned}.*\" SET c.owned=True RETURN c.name AS name')
                             logger.highlight(f"Node {user_owned} successfully set as owned in BloodHound")
         except AuthError as e:
             logger.fail(f"Provided Neo4J credentials ({config.get('BloodHound', 'bh_user')}:{config.get('BloodHound', 'bh_pass')}) are not valid.")


### PR DESCRIPTION
- 413d0b4edec082cf0adbdf640bad062c6b233588 :   when performing a login without providing the full FQDN (e.g., DOMAIN/USER. not DOMAIN.LOCAL/USER) it was giving an error similar to  #529 , Therefore, I found it appropriate to add a regex match in the query for Neo4j to ensure compatibility. Of course, the full FQDN can still be used in query, 