### PR TITLE
we encounter this error on unsupported SMB version

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -629,7 +629,10 @@ class smb(connection):
         except:
             pass
         else:
-            dce.bind(scmr.MSRPC_UUID_SCMR)
+            try:
+                dce.bind(scmr.MSRPC_UUID_SCMR)
+            except:
+                pass
             try:
                 # 0xF003F - SC_MANAGER_ALL_ACCESS
                 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx


### PR DESCRIPTION
- 93e7a5b26a6e5cc6be7fe6ee1f71ca6bc05c596b #252: I also encountered the same problem mentioned in issue . It seems that we encounter this error on unsupported SMB versions (likely non-Windows devices such as NAS). This error was causing the program to exit completely when running cme with a list. Therefore, I thought it would be a good idea to add a try-catch block to handle this scenario.