### PR TITLE
Fix #41

### DIFF
--- a/cme/cli.py
+++ b/cme/cli.py
@@ -112,7 +112,7 @@ def gen_cli_args():
     std_parser = argparse.ArgumentParser(add_help=False)
     std_parser.add_argument(
         "target",
-        nargs="+" if not module_parser.parse_known_args()[0].list_modules else "*",
+        nargs="+" if not module_parser.parse_known_args()[0].list_modules or module_parser.parse_known_args()[0].show_module_options else "*",
         type=str,
         help="the target IP(s), range(s), CIDR(s), hostname(s), FQDN(s), file(s) containing a list of targets, NMap XML or .Nessus file(s)",
     )


### PR DESCRIPTION
Allow listing module options without specifing target. See #41 