### PR TITLE
Fix typo in ioxidresolver module description

### DIFF
--- a/cme/modules/IOXIDResolver.py
+++ b/cme/modules/IOXIDResolver.py
@@ -13,7 +13,7 @@ from impacket.dcerpc.v5.dcomrt import IObjectExporter
 
 class CMEModule:
     name = "ioxidresolver"
-    description = "Thie module helps you to identify hosts that have additional active interfaces"
+    description = "This module helps you to identify hosts that have additional active interfaces"
     supported_protocols = ["smb"]
     opsec_safe = True
     multiple_hosts = False


### PR DESCRIPTION
Fix minor typographical error in module description.