### PR TITLE
Version Bump

### DIFF
--- a/cme/cli.py
+++ b/cme/cli.py
@@ -8,10 +8,11 @@ from cme.loaders.protocolloader import ProtocolLoader
 from cme.helpers.logger import highlight
 from termcolor import colored
 from cme.logger import cme_logger
+import importlib.metadata
 
 
 def gen_cli_args():
-    VERSION = "6.0.0"
+    VERSION = importlib.metadata.version("crackmapexec")
     CODENAME = "Bane"
 
     parser = argparse.ArgumentParser(description=f"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "crackmapexec"
-version = "6.0.0"
+version = "6.0.1"
 description = "A swiss army knife for pentesting networks"
 authors = ["Marcello Salvati <byt3bl33d3r@pm.com>", "Martial Puygrenier <mpgn@protonmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Would propose to bump the version because of all the bug fixes. 

cli.py now automatically uses the version from the pyproject.toml