### PR TITLE
Fixing #45

### DIFF
--- a/cme/connection.py
+++ b/cme/connection.py
@@ -236,6 +236,7 @@ class connection(object):
             secret.append(secret_single)
             cred_type.append(cred_type_single)
 
+        if len(secret) != len(data): data = [None] * len(secret)
         return domain, username, owned, secret, cred_type, data
 
     def parse_credentials(self):


### PR DESCRIPTION
Data object was not properly handled in the login function. This now ensures the lists of `data` and `secret` are equal.

Fixes #45 