### PR TITLE
Fix CI pipeline

### DIFF
--- a/.github/workflows/crackmapexec-test.yml
+++ b/.github/workflows/crackmapexec-test.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install poetry
       run: |
-        pipx install poetry --python ${{ matrix.python-version }}
+        pipx install poetry --python python${{ matrix.python-version }}
         poetry --version
         poetry env info
     - name: Install librairies with dev group

--- a/.github/workflows/crackmapexec-test.yml
+++ b/.github/workflows/crackmapexec-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: CrackMapExec Tests on ${{ matrix.os }}
+    name: CrackMapExec Tests for Py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
@@ -24,8 +24,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install poetry
       run: |
-        pipx install poetry
+        pipx install poetry --python ${{ matrix.python-version }}
         poetry --version
+        poetry env info
     - name: Install librairies with dev group
       run: |
         poetry install --with dev


### PR DESCRIPTION
Currently poetry uses python 3.10.6 in every test run despite the python version installed, so every test run is testing on py 3.10.
(Check Actions -> Install poetry, returns "installed package poetry 1.5.1, installed using Python 3.10.6")

This fix forces poetry to use the intended python version