### PR TITLE
Feat: Added flag --no-write-check on smb shares

### DIFF
--- a/cme/cli.py
+++ b/cme/cli.py
@@ -144,6 +144,7 @@ def gen_cli_args():
     )
     std_parser.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication")
     std_parser.add_argument("--no-bruteforce", action="store_true", help="No spray when using file for username and password (user1 => password1, user2 => password2")
+    std_parser.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")
     std_parser.add_argument("--continue-on-success", action="store_true", help="continues authentication attempts even after successes")
     std_parser.add_argument(
         "--use-kcache",

--- a/cme/cli.py
+++ b/cme/cli.py
@@ -144,7 +144,6 @@ def gen_cli_args():
     )
     std_parser.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication")
     std_parser.add_argument("--no-bruteforce", action="store_true", help="No spray when using file for username and password (user1 => password1, user2 => password2")
-    std_parser.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")
     std_parser.add_argument("--continue-on-success", action="store_true", help="continues authentication attempts even after successes")
     std_parser.add_argument(
         "--use-kcache",

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -867,15 +867,16 @@ class smb(connection):
                 self.logger.debug(f"Error checking READ access on share: {error}")
                 pass
 
-            try:
-                self.conn.createDirectory(share_name, temp_dir)
-                self.conn.deleteDirectory(share_name, temp_dir)
-                write = True
-                share_info["access"].append("WRITE")
-            except SessionError as e:
-                error = get_error_string(e)
-                self.logger.debug(f"Error checking WRITE access on share: {error}")
-                pass
+            if not self.args.no_write_check:
+                try:
+                    self.conn.createDirectory(share_name, temp_dir)
+                    self.conn.deleteDirectory(share_name, temp_dir)
+                    write = True
+                    share_info["access"].append("WRITE")
+                except SessionError as e:
+                    error = get_error_string(e)
+                    self.logger.debug(f"Error checking WRITE access on share: {error}")
+                    pass
 
             permissions.append(share_info)
 

--- a/cme/protocols/smb/proto_args.py
+++ b/cme/protocols/smb/proto_args.py
@@ -33,6 +33,8 @@ def proto_args(parser, std_parser, module_parser):
 
         egroup = smb_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
         egroup.add_argument("--shares", action="store_true", help="enumerate shares and access")
+        egroup.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")
+
         egroup.add_argument("--filter-shares", nargs="+",
                             help="Filter share by access, option 'read' 'write' or 'read,write'")
         egroup.add_argument("--sessions", action="store_true", help="enumerate active sessions")


### PR DESCRIPTION
Skip write check on shares (avoid leaving traces when missing delete permissions)
Same name as the one in SMBMap