### PR TITLE
Explicit check as file for argument

### DIFF
--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -130,7 +130,7 @@ def main():
 
     if hasattr(args, "target") and args.target:
         for target in args.target:
-            if exists(target):
+            if exists(target) and os.path.isfile(target):
                 target_file_type = identify_target_file(target)
                 if target_file_type == "nmap":
                     targets.extend(parse_nmap_xml(target, args.protocol))


### PR DESCRIPTION
Use case:
"cme smb 10.10.10.10" when a subdirectory of the name "10.10.10.10" exists in the parent folder.

CrackMapExec throws a "IsADirectoryError: [Errno 21]" error in the above case.