### PR TITLE
Addition to "audit_mode". Reveal the first X characters of password. 

### DIFF
--- a/cme/config.py
+++ b/cme/config.py
@@ -16,8 +16,9 @@ config_log = cme_config.getboolean("CME", "log_mode", fallback=False)
 ignore_opsec = cme_config.getboolean("CME", "ignore_opsec", fallback=False)
 pwned_label = cme_config.get("CME", "pwn3d_label")
 audit_mode = cme_config.get("CME", "audit_mode")
-
+reveal_chars_of_pwd = int(cme_config.get("CME", "reveal_chars_of_pwd"))
 
 # this should probably be put somewhere else, but if it's in the config helpers, there is a circular import
 def process_secret(text):
-    return text if not audit_mode else audit_mode * 8
+    hidden = text[:reveal_chars_of_pwd]
+    return text if not audit_mode else hidden+audit_mode * 8 

--- a/cme/data/cme.conf
+++ b/cme/data/cme.conf
@@ -3,6 +3,7 @@ workspace = default
 last_used_db = smb
 pwn3d_label = Pwn3d!
 audit_mode =
+reveal_chars_of_pwd = 0
 log_mode = False
 ignore_opsec = True
 


### PR DESCRIPTION
New mode that reveals the first X characters of a password if set in cme.conf.

By default would be set to 0 which would not reveal any characters. 


![2](https://github.com/mpgn/CrackMapExec/assets/46513413/f0b788af-63b1-4343-8f80-118f17431ca2)


Personally love the audit mode to help hide passwords from screenshots but sometimes I want to spray a handful of pwds and want to know which pwd was successful right then and there and/or may want to show in a screenshot of an example of different passwords being sprayed and successful without revealing the full pwd and not having to blur it out later. 


![1](https://github.com/mpgn/CrackMapExec/assets/46513413/4671d434-618f-4c7a-b1ff-013496b7ea47)
