### PR TITLE
Fix configparser issue with missing configs

### DIFF
--- a/cme/config.py
+++ b/cme/config.py
@@ -16,7 +16,7 @@ config_log = cme_config.getboolean("CME", "log_mode", fallback=False)
 ignore_opsec = cme_config.getboolean("CME", "ignore_opsec", fallback=False)
 pwned_label = cme_config.get("CME", "pwn3d_label")
 audit_mode = cme_config.get("CME", "audit_mode")
-reveal_chars_of_pwd = int(cme_config.get("CME", "reveal_chars_of_pwd"))
+reveal_chars_of_pwd = int(cme_config.get("CME", "reveal_chars_of_pwd", fallback=0))
 
 # this should probably be put somewhere else, but if it's in the config helpers, there is a circular import
 def process_secret(text):

--- a/cme/config.py
+++ b/cme/config.py
@@ -14,8 +14,8 @@ if "CME" not in cme_config.sections():
 cme_workspace = cme_config.get("CME", "workspace", fallback="default")
 config_log = cme_config.getboolean("CME", "log_mode", fallback=False)
 ignore_opsec = cme_config.getboolean("CME", "ignore_opsec", fallback=False)
-pwned_label = cme_config.get("CME", "pwn3d_label")
-audit_mode = cme_config.get("CME", "audit_mode")
+pwned_label = cme_config.get("CME", "pwn3d_label", fallback="Pwn3d!")
+audit_mode = cme_config.get("CME", "audit_mode", fallback=False)
 reveal_chars_of_pwd = int(cme_config.get("CME", "reveal_chars_of_pwd", fallback=0))
 
 # this should probably be put somewhere else, but if it's in the config helpers, there is a circular import


### PR DESCRIPTION
When upgrading from older versions it can happen that config options are missing, like from the PR #80 which result in an key error. 
This will introduce more fallbacks for the cme config variables so if there is an outdated config file cme doesn’t crash.