### PR TITLE
Add color to "signing" and "SMBv1" smb output #92

### DIFF
--- a/cme/protocols/ldap.py
+++ b/cme/protocols/ldap.py
@@ -9,6 +9,7 @@ from binascii import hexlify
 from datetime import datetime
 from re import sub, I
 from zipfile import ZipFile
+from termcolor import colored
 
 from Cryptodome.Hash import MD4
 from OpenSSL.SSL import SysCallError
@@ -304,7 +305,9 @@ class ldap(connection):
         else:
             self.logger.extra["protocol"] = "SMB" if not self.no_ntlm else "LDAP"
             self.logger.extra["port"] = "445" if not self.no_ntlm else "389"
-            self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) (signing:{self.signing}) (SMBv1:{self.smbv1})")
+            signing = colored(f"signing:{self.signing}", 'green') if self.signing else colored(f"signing:{self.signing}", 'red')
+            smbv1 = colored(f"SMBv1:{self.smbv1}", 'yellow') if self.smbv1 else colored(f"SMBv1:{self.smbv1}", 'blue')
+            self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
             self.logger.extra["protocol"] = "LDAP"
             # self.logger.display(self.endpoint)
         return True

--- a/cme/protocols/rdp.py
+++ b/cme/protocols/rdp.py
@@ -5,10 +5,14 @@ import asyncio
 import os
 from datetime import datetime
 from os import getenv
+from termcolor import colored
+
 from impacket.krb5.ccache import CCache
+
 from cme.connection import *
 from cme.helpers.bloodhound import add_user_bh
 from cme.logger import CMEAdapter
+
 from aardwolf.connection import RDPConnection
 from aardwolf.commons.queuedata.constants import VIDEO_FORMAT
 from aardwolf.commons.iosettings import RDPIOSettings
@@ -99,10 +103,11 @@ class rdp(connection):
         )
 
     def print_host_info(self):
+        nla = colored(f"nla:{self.nla}", 'blue') if self.nla else colored(f"nla:{self.nla}", 'yellow')
         if self.domain is None:
-            self.logger.display("Probably old, doesn't not support HYBRID or HYBRID_EX" f" (nla:{self.nla})")
+            self.logger.display("Probably old, doesn't not support HYBRID or HYBRID_EX" f" ({nla})")
         else:
-            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})" f" (nla:{self.nla})")
+            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})" f" ({nla})")
         return True
 
     def create_conn_obj(self):

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -64,6 +64,7 @@ from functools import wraps
 from traceback import format_exc
 import logging
 from json import loads
+from termcolor import colored
 
 smb_share_name = gen_random_string(5).upper()
 smb_server = None
@@ -360,7 +361,9 @@ class smb(connection):
         return True
 
     def print_host_info(self):
-        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) (signing:{self.signing}) (SMBv1:{self.smbv1})")
+        signing = colored(f"signing:{self.signing}", 'green') if self.signing else colored(f"signing:{self.signing}", 'red')
+        smbv1 = colored(f"SMBv1:{self.smbv1}", 'yellow') if self.smbv1 else colored(f"SMBv1:{self.smbv1}", 'blue')
+        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
         if self.args.laps:
             return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)
         return True


### PR DESCRIPTION
As requested in #92 this adds colored output for the "signing" and "SMBv1" variables when cme displays an SMB-Connection.