### PR TITLE
[rdp] Avoid hanging

### DIFF
--- a/cme/protocols/rdp.py
+++ b/cme/protocols/rdp.py
@@ -144,7 +144,7 @@ class rdp(connection):
                         self.logger.extra["hostname"] = self.hostname
                         self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
                     break
-
+        
         if self.args.domain:
             self.domain = self.args.domain
 
@@ -179,7 +179,7 @@ class rdp(connection):
                 pass
 
     async def connect_rdp(self):
-        _, err = await self.conn.connect()
+        _, err = await asyncio.wait_for(self.conn.connect(), timeout=self.args.rdp_timeout)
         if err is not None:
             raise err
 
@@ -371,7 +371,7 @@ class rdp(connection):
         self.iosettings.supported_protocols = None
         self.auth = NTLMCredential(secret="", username="", domain="", stype=asyauthSecret.PASS)
         self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-        await self.connect_rdp_old(self.url)
+        await self.connect_rdp()
         await asyncio.sleep(int(self.args.screentime))
 
         if self.conn is not None and self.conn.desktop_buffer_has_data is True:

--- a/cme/protocols/rdp.py
+++ b/cme/protocols/rdp.py
@@ -144,7 +144,7 @@ class rdp(connection):
                         self.logger.extra["hostname"] = self.hostname
                         self.output_filename = os.path.expanduser(f"~/.cme/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
                     break
-        
+
         if self.args.domain:
             self.domain = self.args.domain
 

--- a/cme/protocols/rdp/proto_args.py
+++ b/cme/protocols/rdp/proto_args.py
@@ -2,7 +2,7 @@ def proto_args(parser, std_parser, module_parser):
     rdp_parser = parser.add_parser('rdp', help="own stuff using RDP", parents=[std_parser, module_parser])
     rdp_parser.add_argument("-H", '--hash', metavar="HASH", dest='hash', nargs='+', default=[], help='NTLM hash(es) or file(s) containing NTLM hashes')
     rdp_parser.add_argument("--port", type=int, default=3389, help="Custom RDP port")
-    rdp_parser.add_argument("--rdp-timeout", type=int, default=5, help="RDP timeout on socket connection, defalut is 5s")
+    rdp_parser.add_argument("--rdp-timeout", type=int, default=5, help="RDP timeout on socket connection, defalut is %(default)ss")
     rdp_parser.add_argument("--nla-screenshot", action="store_true", help="Screenshot RDP login prompt if NLA is disabled")
 
     dgroup = rdp_parser.add_mutually_exclusive_group()
@@ -11,7 +11,7 @@ def proto_args(parser, std_parser, module_parser):
 
     egroup = rdp_parser.add_argument_group("Screenshot", "Remote Desktop Screenshot")
     egroup.add_argument("--screenshot", action="store_true", help="Screenshot RDP if connection success")
-    egroup.add_argument('--screentime', type=int, default=10, help='Time to wait for desktop image, default is 10s')
+    egroup.add_argument('--screentime', type=int, default=10, help='Time to wait for desktop image, default is %(default)ss')
     egroup.add_argument('--res', default='1024x768', help='Resolution in "WIDTHxHEIGHT" format. Default: "1024x768"')
 
     return parser

--- a/cme/protocols/rdp/proto_args.py
+++ b/cme/protocols/rdp/proto_args.py
@@ -2,7 +2,7 @@ def proto_args(parser, std_parser, module_parser):
     rdp_parser = parser.add_parser('rdp', help="own stuff using RDP", parents=[std_parser, module_parser])
     rdp_parser.add_argument("-H", '--hash', metavar="HASH", dest='hash', nargs='+', default=[], help='NTLM hash(es) or file(s) containing NTLM hashes')
     rdp_parser.add_argument("--port", type=int, default=3389, help="Custom RDP port")
-    rdp_parser.add_argument("--rdp-timeout", type=int, default=1, help="RDP timeout on socket connection")
+    rdp_parser.add_argument("--rdp-timeout", type=int, default=5, help="RDP timeout on socket connection, defalut is 5s")
     rdp_parser.add_argument("--nla-screenshot", action="store_true", help="Screenshot RDP login prompt if NLA is disabled")
 
     dgroup = rdp_parser.add_mutually_exclusive_group()
@@ -11,7 +11,7 @@ def proto_args(parser, std_parser, module_parser):
 
     egroup = rdp_parser.add_argument_group("Screenshot", "Remote Desktop Screenshot")
     egroup.add_argument("--screenshot", action="store_true", help="Screenshot RDP if connection success")
-    egroup.add_argument('--screentime', type=int, default=10, help='Time to wait for desktop image')
+    egroup.add_argument('--screentime', type=int, default=10, help='Time to wait for desktop image, default is 10s')
     egroup.add_argument('--res', default='1024x768', help='Resolution in "WIDTHxHEIGHT" format. Default: "1024x768"')
 
     return parser


### PR DESCRIPTION
Changes:
1. Increased the rdp timeout
2. self.conn.connect in `asyncio.wait_for`

Before:
- Will hanging even scan finish.
![image](https://github.com/mpgn/CrackMapExec/assets/30458572/1e468493-8b80-4ef5-812c-1716b76ee6ad)

After:
- No more hanging
![image](https://github.com/mpgn/CrackMapExec/assets/30458572/05216bfa-c786-402a-adc0-e8075d938f29)

Because use `wait_for`, so we need to increase the `rdp-timeout`

- By default `1s`
![image](https://github.com/mpgn/CrackMapExec/assets/30458572/65a123e5-e658-43a2-a8df-8d6a902943bb)

- `5s`
![image](https://github.com/mpgn/CrackMapExec/assets/30458572/5affa278-c52e-414e-a8da-872edbe749f5)
