### PR TITLE
Add audit mode and reveal X pwd chars to RDP protocol

### DIFF
--- a/cme/protocols/rdp.py
+++ b/cme/protocols/rdp.py
@@ -248,7 +248,7 @@ class rdp(connection):
                         # Show what was used between cleartext, nthash, aesKey and ccache
                         " from ccache"
                         if useCache
-                        else ":%s" % (kerb_pass if not self.config.get("CME", "audit_mode") else self.config.get("CME", "audit_mode") * 8)
+                        else ":%s" % (process_secret(kerb_pass))
                     ),
                     self.mark_pwned(),
                 )
@@ -264,11 +264,11 @@ class rdp(connection):
                     if word in str(e):
                         reason = self.rdp_error_status[word]
                 self.logger.fail(
-                    (f"{domain}\\{username}{' from ccache' if useCache else ':%s' % (kerb_pass if not self.config.get('CME', 'audit_mode') else self.config.get('CME', 'audit_mode') * 8)} {f'({reason})' if reason else str(e)}"),
+                    (f"{domain}\\{username}{' from ccache' if useCache else ':%s' % (process_secret(kerb_pass))} {f'({reason})' if reason else str(e)}"),
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "KDC_ERR_C_PRINCIPAL_UNKNOWN") else "red"),
                 )
             elif "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{password} {self.mark_pwned()}")
+                self.logger.success(f"{domain}\\{username}:{(process_secret(password))} {self.mark_pwned()}")
             elif "No such file" in str(e):
                 self.logger.fail(e)
             else:
@@ -279,7 +279,7 @@ class rdp(connection):
                 if "cannot unpack non-iterable NoneType object" == str(e):
                     reason = "User valid but cannot connect"
                 self.logger.fail(
-                    (f"{domain}\\{username}{' from ccache' if useCache else ':%s' % (kerb_pass if not self.config.get('CME', 'audit_mode') else self.config.get('CME', 'audit_mode') * 8)} {f'({reason})' if reason else ''}"),
+                    (f"{domain}\\{username}{' from ccache' if useCache else ':%s' % (process_secret(kerb_pass))} {f'({reason})' if reason else ''}"),
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "STATUS_LOGON_FAILURE") else "red"),
                 )
             return False

--- a/cme/protocols/rdp.py
+++ b/cme/protocols/rdp.py
@@ -13,8 +13,7 @@ from cme.connection import *
 from cme.helpers.bloodhound import add_user_bh
 from cme.logger import CMEAdapter
 from cme.config import host_info_colors
-from cme.config import reveal_chars_of_pwd
-from cme.config import audit_mode
+from cme.config import process_secret
 
 from aardwolf.connection import RDPConnection
 from aardwolf.commons.queuedata.constants import VIDEO_FORMAT
@@ -297,13 +296,13 @@ class rdp(connection):
             asyncio.run(self.connect_rdp())
 
             self.admin_privs = True
-            self.logger.success(f"{domain}\\{username}:{password if not self.config.get('CME', 'audit_mode') else password[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
+            self.logger.success(f"{domain}\\{username}:{process_secret(password)} {self.mark_pwned()}")
             if not self.args.local_auth:
                 add_user_bh(username, domain, self.logger, self.config)
             return True
         except Exception as e:
             if "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{password if not self.config.get('CME', 'audit_mode') else password[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
+                self.logger.success(f"{domain}\\{username}:{process_secret(password)} {self.mark_pwned()}")
             else:
                 reason = None
                 for word in self.rdp_error_status.keys():
@@ -312,7 +311,7 @@ class rdp(connection):
                 if "cannot unpack non-iterable NoneType object" == str(e):
                     reason = "User valid but cannot connect"
                 self.logger.fail(
-                    (f"{domain}\\{username}:{password if not self.config.get('CME', 'audit_mode') else password[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {f'({reason})' if reason else ''}"),
+                    (f"{domain}\\{username}:{process_secret(password)} {f'({reason})' if reason else ''}"),
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "STATUS_LOGON_FAILURE") else "red"),
                 )
             return False
@@ -329,13 +328,13 @@ class rdp(connection):
             asyncio.run(self.connect_rdp())
 
             self.admin_privs = True
-            self.logger.success(f"{self.domain}\\{username}:{ntlm_hash if not self.config.get('CME', 'audit_mode') else ntlm_hash[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
+            self.logger.success(f"{self.domain}\\{username}:{process_secret(ntlm_hash)} {self.mark_pwned()}")
             if not self.args.local_auth:
                 add_user_bh(username, domain, self.logger, self.config)
             return True
         except Exception as e:
             if "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{ntlm_hash if not self.config.get('CME', 'audit_mode') else ntlm_hash[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
+                self.logger.success(f"{domain}\\{username}:{process_secret(ntlm_hash)} {self.mark_pwned()}")
             else:
                 reason = None
                 for word in self.rdp_error_status.keys():
@@ -345,7 +344,7 @@ class rdp(connection):
                     reason = "User valid but cannot connect"
 
                 self.logger.fail(
-                    (f"{domain}\\{username}:{ntlm_hash if not self.config.get('CME', 'audit_mode') else ntlm_hash[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {f'({reason})' if reason else ''}"),
+                    (f"{domain}\\{username}:{process_secret(ntlm_hash)} {f'({reason})' if reason else ''}"),
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "STATUS_LOGON_FAILURE") else "red"),
                 )
             return False

--- a/cme/protocols/rdp.py
+++ b/cme/protocols/rdp.py
@@ -26,13 +26,6 @@ from asyauth.common.credentials.kerberos import KerberosCredential
 from asyauth.common.constants import asyauthSecret
 from asysocks.unicomm.common.target import UniTarget, UniProto
 
-if len(audit_mode)>= 1:
-        hidden = reveal_chars_of_pwd
-        audit = audit_mode*8
-else:
-        hidden = 999
-        audit = ""
-
 class rdp(connection):
     def __init__(self, args, db, host):
         self.domain = None
@@ -304,13 +297,13 @@ class rdp(connection):
             asyncio.run(self.connect_rdp())
 
             self.admin_privs = True
-            self.logger.success(f"{domain}\\{username}:{password[:hidden]+audit} {self.mark_pwned()}")
+            self.logger.success(f"{domain}\\{username}:{password if not self.config.get('CME', 'audit_mode') else password[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
             if not self.args.local_auth:
                 add_user_bh(username, domain, self.logger, self.config)
             return True
         except Exception as e:
             if "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{password[:hidden]+audit} {self.mark_pwned()}")
+                self.logger.success(f"{domain}\\{username}:{password if not self.config.get('CME', 'audit_mode') else password[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
             else:
                 reason = None
                 for word in self.rdp_error_status.keys():
@@ -319,7 +312,7 @@ class rdp(connection):
                 if "cannot unpack non-iterable NoneType object" == str(e):
                     reason = "User valid but cannot connect"
                 self.logger.fail(
-                    (f"{domain}\\{username}:{password[:hidden]+audit} {f'({reason})' if reason else ''}"),
+                    (f"{domain}\\{username}:{password if not self.config.get('CME', 'audit_mode') else password[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {f'({reason})' if reason else ''}"),
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "STATUS_LOGON_FAILURE") else "red"),
                 )
             return False
@@ -336,13 +329,13 @@ class rdp(connection):
             asyncio.run(self.connect_rdp())
 
             self.admin_privs = True
-            self.logger.success(f"{self.domain}\\{username}:{ntlm_hash[:hidden]+audit} {self.mark_pwned()}")
+            self.logger.success(f"{self.domain}\\{username}:{ntlm_hash if not self.config.get('CME', 'audit_mode') else ntlm_hash[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
             if not self.args.local_auth:
                 add_user_bh(username, domain, self.logger, self.config)
             return True
         except Exception as e:
             if "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{ntlm_hash[:hidden]+audit} {self.mark_pwned()}")
+                self.logger.success(f"{domain}\\{username}:{ntlm_hash if not self.config.get('CME', 'audit_mode') else ntlm_hash[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {self.mark_pwned()}")
             else:
                 reason = None
                 for word in self.rdp_error_status.keys():
@@ -352,7 +345,7 @@ class rdp(connection):
                     reason = "User valid but cannot connect"
 
                 self.logger.fail(
-                    (f"{domain}\\{username}:{ntlm_hash[:hidden]+audit} {f'({reason})' if reason else ''}"),
+                    (f"{domain}\\{username}:{ntlm_hash if not self.config.get('CME', 'audit_mode') else ntlm_hash[:reveal_chars_of_pwd]+self.config.get('CME', 'audit_mode') * 8} {f'({reason})' if reason else ''}"),
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "STATUS_LOGON_FAILURE") else "red"),
                 )
             return False


### PR DESCRIPTION
Add audit mode and reveal X pwd chars to RDP protocol.

Without audit mode:
![image](https://github.com/mpgn/CrackMapExec/assets/46513413/cfc8cffe-0e7d-490c-b607-98f1b8e7b115)
![image](https://github.com/mpgn/CrackMapExec/assets/46513413/2380073f-1bcd-471e-a8c3-b74fdb2807e0)


With audit mode:
![image](https://github.com/mpgn/CrackMapExec/assets/46513413/fc3b2f37-fc52-445d-87d9-4452bd82c9da)

![image](https://github.com/mpgn/CrackMapExec/assets/46513413/fbd2daae-5070-4b15-99c0-c81743ec00f9)
