### PR TITLE
[smb] Move firewall_checker to built-in function & Rewrite RDP module #66 & bugs fix

### DIFF
--- a/cme/modules/get_netconnections.py
+++ b/cme/modules/get_netconnections.py
@@ -28,11 +28,12 @@ class CMEModule:
     def on_admin_login(self, context, connection):
         data = []
         cards = connection.wmi(f"select DNSDomainSuffixSearchOrder, IPAddress from win32_networkadapterconfiguration")
-        for c in cards:
-            if c["IPAddress"].get("value"):
-                context.log.success(f"IP Address: {c['IPAddress']['value']}\tSearch Domain: {c['DNSDomainSuffixSearchOrder']['value']}")
+        if cards:
+            for c in cards:
+                if c["IPAddress"].get("value"):
+                    context.log.success(f"IP Address: {c['IPAddress']['value']}\tSearch Domain: {c['DNSDomainSuffixSearchOrder']['value']}")
 
-        data.append(cards)
+            data.append(cards)
 
         log_name = "network-connections-{}-{}.log".format(connection.args.target[0], datetime.now().strftime("%Y-%m-%d_%H%M%S"))
         write_log(json.dumps(data), log_name)

--- a/cme/modules/rdp.py
+++ b/cme/modules/rdp.py
@@ -31,7 +31,7 @@ class CMEModule:
         ACTION          Enable/Disable RDP (choices: enable, disable, enable-ram, disable-ram)
         METHOD          wmi(ncacn_ip_tcp)/smb(ncacn_np) (choices: wmi, smb, default is wmi)
         OLD             For old version system (under NT6, like: server 2003)
-        DCOM-TIMEOUT    Set the Dcom connection timeout for WMI method
+        DCOM-TIMEOUT    Set the Dcom connection timeout for WMI method (Default is 10 seconds)
         cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}
         cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=smb ACTION={enable, disable, enable-ram, disable-ram}
         cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=wmi ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}

--- a/cme/modules/rdp.py
+++ b/cme/modules/rdp.py
@@ -28,8 +28,10 @@ class CMEModule:
 
     def options(self, context, module_options):
         """
-        ACTION       Enable/Disable RDP (choices: enable, disable, enable-ram, disable-ram)
-        METHOD       wmi(ncacn_ip_tcp)/smb(ncacn_np) (choices: wmi, smb, default is wmi)
+        ACTION          Enable/Disable RDP (choices: enable, disable, enable-ram, disable-ram)
+        METHOD          wmi(ncacn_ip_tcp)/smb(ncacn_np) (choices: wmi, smb, default is wmi)
+        OLD             For old version system (under NT6, like: server 2003)
+        DCOM-TIMEOUT    Set the Dcom connection timeout for WMI method
         cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}
         cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=smb ACTION={enable, disable, enable-ram, disable-ram}
         cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=wmi ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}
@@ -70,7 +72,7 @@ class CMEModule:
     def on_admin_login(self, context, connection):
         # Preparation for wmi protocol
         if self.method == "smb":
-            context.log.info("Doing action with SMB(ncacn_np)")
+            context.log.info("Executing over SMB(ncacn_np)")
             try:
                 smb_rdp = rdp_SMB(context, connection)
                 if "ram" in self.action:
@@ -80,7 +82,7 @@ class CMEModule:
             except Exception as e:
                 context.log.fail(f"Enable RDP via smb error: {str(e)}")
         elif self.method == "wmi":
-            context.log.info("Doing action with WMI(ncacn_ip_tcp)")
+            context.log.info("Executing over WMI(ncacn_ip_tcp)")
             try:
                 wmi_rdp = rdp_WMI(context, connection, self.dcom_timeout)
             except Exception as e:

--- a/cme/modules/rdp.py
+++ b/cme/modules/rdp.py
@@ -86,8 +86,8 @@ class CMEModule:
             except Exception as e:
                 context.log.fail(f"Unexpected wmi error: {str(e)}")
                 wmi_rdp._rdp_WMI__dcom.disconnect()
-            
-            if wmi_rdp:
+
+            if hasattr(wmi_rdp, '_rdp_WMI__iWbemLevel1Login'):
                 if "ram" in self.action:
                     # Nt version under 6 not support RAM.
                     try:
@@ -98,7 +98,7 @@ class CMEModule:
                         else:
                             context.log.fail(str(e))
                         pass
-                    wmi_rdp._rdp_WMI__dcom.disconnect()
+                        wmi_rdp._rdp_WMI__dcom.disconnect()
                 else:
                     try:
                         wmi_rdp.rdp_Wrapper(self.action, self.oldSystem)
@@ -237,7 +237,7 @@ class rdp_WMI:
                 self.logger.fail(f'WMIEXEC: Dcom initialization failed on connection with stringbinding: "{self.__stringBinding}", please increase the timeout with the module option "DCOM-TIMEOUT=10". If it\'s still failing maybe something is blocking the RPC connection, try "METHOD=smb"')
                 # Make it force break function
                 self.__dcom.disconnect()
-                return False
+                return
         self.__iWbemLevel1Login = wmi.IWbemLevel1Login(iInterface)
         
     def rdp_Wrapper(self, action, old=False):

--- a/cme/modules/rdp.py
+++ b/cme/modules/rdp.py
@@ -3,14 +3,21 @@
 
 from sys import exit
 
+from cme.connection import dcom_FirewallChecker
+
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
+from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.dcom import wmi
+from impacket.dcerpc.v5.dtypes import NULL
+from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 
 
 class CMEModule:
     name = "rdp"
     description = "Enables/Disables RDP"
-    supported_protocols = ["smb"]
+    #supported_protocols = ["smb"]
+    supported_protocols = ["smb" ,"wmi"]
     opsec_safe = True
     multiple_hosts = True
 
@@ -21,26 +28,96 @@ class CMEModule:
 
     def options(self, context, module_options):
         """
-        ACTION       Enable/Disable RDP (choices: enable, disable)
+        ACTION       Enable/Disable RDP (choices: enable, disable, enable-ram, disable-ram)
+        METHOD       wmi(ncacn_ip_tcp)/smb(ncacn_np) (choices: wmi, smb, default is wmi)
+        cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}
+        cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=smb ACTION={enable, disable, enable-ram, disable-ram}
+        cme smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=wmi ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}
         """
         if not "ACTION" in module_options:
             context.log.fail("ACTION option not specified!")
             exit(1)
 
-        if module_options["ACTION"].lower() not in ["enable", "disable"]:
+        if module_options["ACTION"].lower() not in ["enable", "disable", "enable-ram", "disable-ram"]:
             context.log.fail("Invalid value for ACTION option!")
             exit(1)
 
         self.action = module_options["ACTION"].lower()
+        
+        if not "METHOD" in module_options:
+            self.method = "wmi"
+        else:
+            self.method = module_options['METHOD'].lower()
+        
+        if context.protocol != "smb" and self.method == "smb":
+            context.log.fail(f"Protocol: {context.protocol} not support this method")
+            exit(1)
+
+        if not "DCOM-TIMEOUT" in module_options:
+            self.dcom_timeout = 10
+        else:
+            try:
+                self.dcom_timeout = int(module_options['DCOM-TIMEOUT'])
+            except:
+                context.log.fail("Wrong DCOM timeout value!")
+                exit(1)
+        
+        if not "OLD" in module_options:
+            self.oldSystem = False
+        else:
+            self.oldSystem = True
 
     def on_admin_login(self, context, connection):
-        if self.action == "enable":
-            self.rdp_enable(context, connection.conn)
-        elif self.action == "disable":
-            self.rdp_disable(context, connection.conn)
+        # Preparation for wmi protocol
+        if self.method == "smb":
+            context.log.info("Doing action with SMB(ncacn_np)")
+            try:
+                smb_rdp = rdp_SMB(context, connection)
+                if "ram" in self.action:
+                    smb_rdp.rdp_RAMWrapper(self.action)
+                else:
+                    smb_rdp.rdp_Wrapper(self.action)
+            except Exception as e:
+                context.log.fail(f"Enable RDP via smb error: {str(e)}")
+        elif self.method == "wmi":
+            context.log.info("Doing action with WMI(ncacn_ip_tcp)")
+            try:
+                wmi_rdp = rdp_WMI(context, connection, self.dcom_timeout)
+            except Exception as e:
+                context.log.fail(f"Unexpected wmi error: {str(e)}")
+                wmi_rdp._rdp_WMI__dcom.disconnect()
+            
+            if wmi_rdp:
+                if "ram" in self.action:
+                    # Nt version under 6 not support RAM.
+                    try:
+                        wmi_rdp.rdp_RAMWrapper(self.action)
+                    except Exception as e:
+                        if "WBEM_E_NOT_FOUND" in str(e):
+                            context.log.fail("System version under NT6 not support restricted admin mode")
+                        else:
+                            context.log.fail(str(e))
+                        pass
+                    wmi_rdp._rdp_WMI__dcom.disconnect()
+                else:
+                    try:
+                        wmi_rdp.rdp_Wrapper(self.action, self.oldSystem)
+                    except Exception as e:
+                        if "WBEM_E_INVALID_NAMESPACE" in str(e):
+                            context.log.fail('Looks like target system version is under NT6, please add "OLD=true" in module options.')
+                        else:
+                            context.log.fail(str(e))
+                        pass
+                    wmi_rdp._rdp_WMI__dcom.disconnect()
 
-    def rdp_enable(self, context, smbconnection):
-        remoteOps = RemoteOperations(smbconnection, False)
+class rdp_SMB:
+    def __init__(self, context, connection):
+        self.context = context
+        self.__smbconnection = connection.conn
+        self.logger = context.log
+
+    def rdp_Wrapper(self, action):
+        remoteOps = RemoteOperations(self.__smbconnection, False)
         remoteOps.enableRegistry()
 
         if remoteOps._RemoteOperations__rrp:
@@ -54,26 +131,30 @@ class CMEModule:
             )
             keyHandle = ans["phkResult"]
 
-            rrp.hBaseRegSetValue(
+            ans = rrp.hBaseRegSetValue(
                 remoteOps._RemoteOperations__rrp,
                 keyHandle,
-                "fDenyTSConnections\x00",
+                "fDenyTSConnections",
                 rrp.REG_DWORD,
-                0,
+                0 if action == "enable" else 1,
             )
 
-            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "fDenyTSConnections\x00")
+            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "fDenyTSConnections")
 
             if int(data) == 0:
-                context.log.success("RDP enabled successfully")
+                self.logger.success("Enable RDP via SMB(ncacn_np) successfully")
+            elif int(data) == 1:
+                self.logger.success("Disable RDP via SMB(ncacn_np) successfully")
 
+            if action == "enable":
+                self.query_RDPPort(remoteOps, regHandle)
         try:
             remoteOps.finish()
         except:
             pass
 
-    def rdp_disable(self, context, smbconnection):
-        remoteOps = RemoteOperations(smbconnection, False)
+    def rdp_RAMWrapper(self, action):
+        remoteOps = RemoteOperations(self.__smbconnection, False)
         remoteOps.enableRegistry()
 
         if remoteOps._RemoteOperations__rrp:
@@ -83,24 +164,158 @@ class CMEModule:
             ans = rrp.hBaseRegOpenKey(
                 remoteOps._RemoteOperations__rrp,
                 regHandle,
-                "SYSTEM\\CurrentControlSet\\Control\\Terminal Server",
+                "System\\CurrentControlSet\\Control\\Lsa",
             )
             keyHandle = ans["phkResult"]
 
             rrp.hBaseRegSetValue(
                 remoteOps._RemoteOperations__rrp,
                 keyHandle,
-                "fDenyTSConnections\x00",
+                "DisableRestrictedAdmin",
                 rrp.REG_DWORD,
-                1,
+                0 if action == "enable-ram" else 1,
             )
 
-            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "fDenyTSConnections\x00")
+            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "DisableRestrictedAdmin")
 
-            if int(data) == 1:
-                context.log.success("RDP disabled successfully")
+            if int(data) == 0:
+                self.logger.success("Enable RDP Restricted Admin Mode via SMB(ncacn_np) successfully")
+            elif int(data) == 1:
+                self.logger.success("Disable RDP Restricted Admin Mode via SMB(ncacn_np) successfully")
 
         try:
             remoteOps.finish()
         except:
             pass
+
+    def query_RDPPort(self, remoteOps, regHandle):
+        if remoteOps:
+            ans = rrp.hBaseRegOpenKey(
+                remoteOps._RemoteOperations__rrp,
+                regHandle,
+                "SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp",
+            )
+            keyHandle = ans["phkResult"]
+
+            rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "PortNumber")
+            
+            self.logger.success(f"RDP Port: {str(data)}")
+
+class rdp_WMI:
+    def __init__(self, context, connection, timeout):
+        self.logger = context.log
+        self.__currentprotocol = context.protocol
+        # From dfscoerce.py
+        self.__username=connection.username
+        self.__password=connection.password
+        self.__domain=connection.domain
+        self.__lmhash=connection.lmhash
+        self.__nthash=connection.nthash
+        self.__target=connection.host if not connection.kerberos else connection.hostname + "." + connection.domain
+        self.__doKerberos=connection.kerberos
+        self.__kdcHost=connection.kdcHost
+        self.__aesKey=connection.aesKey
+        self.__timeout = timeout
+
+        self.__dcom = DCOMConnection(
+            self.__target,
+            self.__username,
+            self.__password,
+            self.__domain,
+            self.__lmhash,
+            self.__nthash,
+            self.__aesKey,
+            oxidResolver=True,
+            doKerberos=self.__doKerberos,
+            kdcHost=self.__kdcHost,
+        )
+
+        iInterface = self.__dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
+        if self.__currentprotocol == "smb":
+            flag, self.__stringBinding =  dcom_FirewallChecker(iInterface, self.__timeout)
+            if not flag:
+                self.logger.fail(f'WMIEXEC: Dcom initialization failed on connection with stringbinding: "{self.__stringBinding}", please increase the timeout with the module option "DCOM-TIMEOUT=10". If it\'s still failing maybe something is blocking the RPC connection, try "METHOD=smb"')
+                # Make it force break function
+                self.__dcom.disconnect()
+                return False
+        self.__iWbemLevel1Login = wmi.IWbemLevel1Login(iInterface)
+        
+    def rdp_Wrapper(self, action, old=False):
+        if old == False:
+            # According to this document: https://learn.microsoft.com/en-us/windows/win32/termserv/win32-tslogonsetting
+            # Authentication level must set to RPC_C_AUTHN_LEVEL_PKT_PRIVACY when accessing namespace "//./root/cimv2/TerminalServices"
+            iWbemServices = self.__iWbemLevel1Login.NTLMLogin('//./root/cimv2/TerminalServices', NULL, NULL)
+            iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+            self.__iWbemLevel1Login.RemRelease()
+            iEnumWbemClassObject = iWbemServices.ExecQuery("SELECT * FROM Win32_TerminalServiceSetting")
+            iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff,1)[0]
+            if action == 'enable':
+                self.logger.info("Enabled RDP services and setting up firewall.")
+                iWbemClassObject.SetAllowTSConnections(1,1)
+                self.query_RDPPort()
+            elif action == 'disable':
+                self.logger.info("Disabled RDP services and setting up firewall.")
+                iWbemClassObject.SetAllowTSConnections(0,0)
+        else:
+            iWbemServices = self.__iWbemLevel1Login.NTLMLogin('//./root/cimv2', NULL, NULL)
+            self.__iWbemLevel1Login.RemRelease()
+            iEnumWbemClassObject = iWbemServices.ExecQuery("SELECT * FROM Win32_TerminalServiceSetting")
+            iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff,1)[0]
+            if action == 'enable':
+                self.logger.info("Enabling RDP services (old system not support setting up firewall)")
+                iWbemClassObject.SetAllowTSConnections(1)
+                self.query_RDPPort()
+            elif action == 'disable':
+                self.logger.info("Disabling RDP services (old system not support setting up firewall)")
+                iWbemClassObject.SetAllowTSConnections(0)
+        # Need to create new iWbemServices interface in order to flush results
+        self.query_RDPResult(old)
+        
+    def query_RDPResult(self, old=False):
+        if old == False:
+            iWbemServices = self.__iWbemLevel1Login.NTLMLogin('//./root/cimv2/TerminalServices', NULL, NULL)
+            iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+            self.__iWbemLevel1Login.RemRelease()
+            iEnumWbemClassObject = iWbemServices.ExecQuery("SELECT * FROM Win32_TerminalServiceSetting")
+            iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff,1)[0]
+            result = dict(iWbemClassObject.getProperties())
+            result = result['AllowTSConnections']['value']
+            if result == 0:
+                self.logger.success("Disable RDP via WMI(ncacn_ip_tcp) successfully")
+            else:
+                self.logger.success("Enable RDP via WMI(ncacn_ip_tcp) successfully")
+        else:
+            iWbemServices = self.__iWbemLevel1Login.NTLMLogin('//./root/cimv2', NULL, NULL)
+            self.__iWbemLevel1Login.RemRelease()
+            iEnumWbemClassObject = iWbemServices.ExecQuery("SELECT * FROM Win32_TerminalServiceSetting")
+            iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff,1)[0]
+            result = dict(iWbemClassObject.getProperties())
+            result = result['AllowTSConnections']['value']
+            if result == 0:
+                self.logger.success("Disable RDP via WMI(ncacn_ip_tcp) successfully (old system)")
+            else:
+                self.logger.success("Enable RDP via WMI(ncacn_ip_tcp) successfully (old system)")
+
+    def query_RDPPort(self):
+        iWbemServices = self.__iWbemLevel1Login.NTLMLogin('//./root/DEFAULT', NULL, NULL)
+        self.__iWbemLevel1Login.RemRelease()
+        StdRegProv, resp = iWbemServices.GetObject("StdRegProv")
+        out = StdRegProv.GetDWORDValue(2147483650, 'SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp', 'PortNumber')
+        self.logger.success(f"RDP Port: {str(out.uValue)}")
+
+    # Nt version under 6 not support RAM.
+    def rdp_RAMWrapper(self, action):
+        iWbemServices = self.__iWbemLevel1Login.NTLMLogin('//./root/cimv2', NULL, NULL)
+        self.__iWbemLevel1Login.RemRelease()
+        StdRegProv, resp = iWbemServices.GetObject("StdRegProv")
+        if action == 'enable-ram':
+            self.logger.info("Enabling Restricted Admin Mode.")
+            StdRegProv.SetDWORDValue(2147483650, 'System\\CurrentControlSet\\Control\\Lsa', 'DisableRestrictedAdmin', 0)
+        elif action == 'disable-ram':
+            self.logger.info("Disabling Restricted Admin Mode (Clear).")
+            StdRegProv.DeleteValue(2147483650, 'System\\CurrentControlSet\\Control\\Lsa', 'DisableRestrictedAdmin')
+        out = StdRegProv.GetDWORDValue(2147483650, 'System\\CurrentControlSet\\Control\\Lsa', 'DisableRestrictedAdmin')
+        if out.uValue == 0:
+            self.logger.success("Enable RDP Restricted Admin Mode via WMI(ncacn_ip_tcp) successfully")
+        elif out.uValue == None:
+            self.logger.success("Disable RDP Restricted Admin Mode via WMI(ncacn_ip_tcp) successfully")

--- a/cme/modules/rdp.py
+++ b/cme/modules/rdp.py
@@ -98,7 +98,7 @@ class CMEModule:
                         else:
                             context.log.fail(str(e))
                         pass
-                        wmi_rdp._rdp_WMI__dcom.disconnect()
+                    wmi_rdp._rdp_WMI__dcom.disconnect()
                 else:
                     try:
                         wmi_rdp.rdp_Wrapper(self.action, self.oldSystem)

--- a/cme/modules/wcc.py
+++ b/cme/modules/wcc.py
@@ -503,7 +503,7 @@ class HostChecker:
 
     def check_last_successful_update(self):
         records = self.connection.wmi(wmi_query='Select TimeGenerated FROM Win32_ReliabilityRecords Where EventIdentifier=19', namespace='root\\cimv2')
-        if len(records) == 0:
+        if isinstance(records, bool) or len(records) == 0:
             return False, ['No update found']
         most_recent_update_date = records[0]['TimeGenerated']['value']
         most_recent_update_date = most_recent_update_date.split('.')[0]

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -1219,7 +1219,18 @@ class smb(connection):
             namespace = self.args.wmi_namespace
 
         try:
-            dcom = DCOMConnection(self.host, self.username, self.password, self.domain, self.lmhash, self.nthash, oxidResolver=True, doKerberos=self.kerberos ,kdcHost=self.kdcHost, aesKey=self.aesKey)
+            dcom = DCOMConnection(
+                self.host if not self.kerberos else self.hostname + "." + self.domain,
+                self.username,
+                self.password,
+                self.domain,
+                self.lmhash,
+                self.nthash,
+                oxidResolver=True,
+                doKerberos=self.kerberos,
+                kdcHost=self.kdcHost,
+                aesKey=self.aesKey
+            )
             iInterface = dcom.CoCreateInstanceEx(CLSID_WbemLevel1Login,IID_IWbemLevel1Login)
             flag, stringBinding =  dcom_FirewallChecker(iInterface, self.args.dcom_timeout)
             if not flag:

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -1235,7 +1235,6 @@ class smb(connection):
             iEnumWbemClassObject = iWbemServices.ExecQuery(wmi_query)
         except Exception as e:
             self.logger.fail('Execute WQL error: {}'.format(e))
-            iWbemServices.RemRelease()
             dcom.disconnect()
             return False
         else:
@@ -1254,7 +1253,6 @@ class smb(connection):
                         break
             try:
                 iEnumWbemClassObject.RemRelease()
-                iWbemServices.RemRelease()
                 dcom.disconnect()
             except:
                 pass

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -1221,7 +1221,7 @@ class smb(connection):
             namespace = self.args.wmi_namespace
 
         try:
-            dcom = DCOMConnection(self.conn.getRemoteName(), self.username, self.password, self.domain, self.lmhash, self.nthash, oxidResolver=True, doKerberos=self.kerberos ,kdcHost=self.kdcHost, aesKey=self.aesKey)
+            dcom = DCOMConnection(self.host, self.username, self.password, self.domain, self.lmhash, self.nthash, oxidResolver=True, doKerberos=self.kerberos ,kdcHost=self.kdcHost, aesKey=self.aesKey)
             iInterface = dcom.CoCreateInstanceEx(CLSID_WbemLevel1Login,IID_IWbemLevel1Login)
             flag, stringBinding =  dcom_FirewallChecker(iInterface, self.args.dcom_timeout)
             if not flag:

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -21,11 +21,13 @@ from impacket.dcerpc.v5.rpcrt import DCERPCException
 from impacket.dcerpc.v5.transport import DCERPCTransportFactory, SMBTransport
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 from impacket.dcerpc.v5.epm import MSRPC_UUID_PORTMAP
-from impacket.dcerpc.v5.dcom.wmi import WBEM_FLAG_FORWARD_ONLY
 from impacket.dcerpc.v5.samr import SID_NAME_USE
 from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
 from impacket.krb5.kerberosv5 import SessionKeyDecryptionError
 from impacket.krb5.types import KerberosException
+from impacket.dcerpc.v5.dtypes import NULL
+from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.dcom.wmi import CLSID_WbemLevel1Login, IID_IWbemLevel1Login, WBEM_FLAG_FORWARD_ONLY, IWbemLevel1Login
 
 from cme.config import process_secret, host_info_colors
 from cme.connection import *
@@ -56,10 +58,6 @@ from dploot.lib.target import Target
 from dploot.lib.smb import DPLootSMBConnection
 
 from pywerview.cli.helpers import *
-
-from impacket.dcerpc.v5.dtypes import NULL
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
-from impacket.dcerpc.v5.dcom.wmi import CLSID_WbemLevel1Login, IID_IWbemLevel1Login, WBEM_FLAG_FORWARD_ONLY, IWbemLevel1Login
 
 from time import time
 from datetime import datetime

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -690,7 +690,7 @@ class smb(connection):
                         self.hash,
                         self.args.share,
                         logger=self.logger,
-                        timeout=self.args.wmiexec_timeout,
+                        timeout=self.args.dcom_timeout,
                         tries=self.args.get_output_tries
                     )
                     self.logger.info("Executed command via wmiexec")
@@ -711,7 +711,8 @@ class smb(connection):
                         self.args.share,
                         self.hash,
                         self.logger,
-                        self.args.get_output_tries
+                        self.args.get_output_tries,
+                        self.args.dcom_timeout
                     )
                     self.logger.info("Executed command via mmcexec")
                     break

--- a/cme/protocols/smb/proto_args.py
+++ b/cme/protocols/smb/proto_args.py
@@ -79,7 +79,7 @@ def proto_args(parser, std_parser, module_parser):
         cgroup = smb_parser.add_argument_group("Command Execution", "Options for executing commands")
         cgroup.add_argument("--exec-method", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default=None,
                             help="method to execute the command. Ignored if in MSSQL mode (default: wmiexec)")
-        cgroup.add_argument("--wmiexec-timeout", help="WMIEXEC connection timeout, default is 5 secondes", type=int, default=5)
+        cgroup.add_argument("--dcom-timeout", help="DCOM connection timeout, default is 5 secondes", type=int, default=5)
         cgroup.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results, default is 5", type=int, default=5)
         cgroup.add_argument("--codec", default="utf-8",
                             help="Set encoding used (codec) from the target's output (default "

--- a/cme/protocols/smb/smbexec.py
+++ b/cme/protocols/smb/smbexec.py
@@ -141,18 +141,21 @@ class SMBEXEC:
         except Exception as e:
             if "rpc_s_access_denied" in str(e):
                 self.logger.fail("SMBEXEC: Create services got blocked.")
-                return self.__outputBuffer
             else:
-                pass
+                self.logger.fail(str(e))
             
+            return self.__outputBuffer
+
         try:
             self.logger.debug(f"Remote service {self.__serviceName} started.")
             scmr.hRStartServiceW(self.__scmr, service)
-        except:
+
+            self.logger.debug(f"Remote service {self.__serviceName} deleted.")
+            scmr.hRDeleteService(self.__scmr, service)
+            scmr.hRCloseServiceHandle(self.__scmr, service)
+        except Exception as e:
             pass
-        self.logger.debug(f"Remote service {self.__serviceName} deleted.")
-        scmr.hRDeleteService(self.__scmr, service)
-        scmr.hRCloseServiceHandle(self.__scmr, service)
+
         self.get_output_remote()
 
     def get_output_remote(self):


### PR DESCRIPTION
Changes:
- Move `firewall_checker` into the built-in function as `dcom_FirewallChecker` 
- SMB/AT/MMC command execution exceptions review.
- Firewall check in MMCExec.
- RDP module has been rewritten #66 