### PR TITLE
[smb] fix server 2003/win7 login issue

### DIFF
--- a/cme/connection.py
+++ b/cme/connection.py
@@ -352,7 +352,7 @@ class connection(object):
         if self.args.continue_on_success and owned:
             return False
         # Enforcing FQDN for SMB if not using local authentication. Related issues/PRs: #26, #28, #24, #38
-        if self.args.protocol == 'smb' and not self.args.local_auth and "." not in domain and not self.args.laps and secret != "" and not (self.domain == self.hostname) :
+        if self.args.protocol == 'smb' and not self.args.local_auth and "." not in domain and not self.args.laps and secret != "" and not (self.domain.upper() == self.hostname.upper()) :
             self.logger.error(f"Domain {domain} for user {username.rstrip()} need to be FQDN ex:domain.local, not domain")
             return False
 

--- a/cme/protocols/smb/atexec.py
+++ b/cme/protocols/smb/atexec.py
@@ -156,7 +156,7 @@ class TSCH_EXEC:
             dce.bind(tsch.MSRPC_UUID_TSCHS)
             tsch.hSchRpcRegisterTask(dce, f"\\{tmpName}", xml, tsch.TASK_CREATE, NULL, tsch.TASK_LOGON_NONE)
         except Exception as e:
-            if hex(e.error_code) == "0x80070005":
+            if e.error_code and hex(e.error_code) == "0x80070005":
                 self.logger.fail("ATEXEC: Create schedule task got blocked.")
             else:
                 self.logger.fail(str(e))


### PR DESCRIPTION
In server 2003/win7, the `domain` from `enum` will given back a lowercase and the `hostname` is given back uppercase. this will break the server 2003 auth.
![image](https://github.com/mpgn/CrackMapExec/assets/30458572/a51b64dd-eec3-42da-a29b-dab29d1ffad2)

So after this PR, it will check each variable in uppercase
![image](https://github.com/mpgn/CrackMapExec/assets/30458572/763cdf73-f3dc-43aa-b0a3-23c493e25033)
